### PR TITLE
feat: add init command to initialize version file with feedback

### DIFF
--- a/cmd/semver/actions.go
+++ b/cmd/semver/actions.go
@@ -8,6 +8,23 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+func initVersion() func(ctx context.Context, cmd *cli.Command) error {
+	return func(ctx context.Context, cmd *cli.Command) error {
+		path := cmd.String("path")
+		created, version, err := semver.InitializeVersionFileWithFeedback(path)
+		if err != nil {
+			return err
+		}
+
+		if created {
+			fmt.Printf("Initialized %s with version %s\n", path, version.String())
+		} else {
+			fmt.Printf("Version file already exists at %s\n", path)
+		}
+		return nil
+	}
+}
+
 // bumpPatch increments the patch version of the .version file.
 func bumpPatch() func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/semver/cli.go
+++ b/cmd/semver/cli.go
@@ -24,6 +24,11 @@ func newCLI(defaultPath string) *cli.Command {
 		},
 		Commands: []*cli.Command{
 			{
+				Name:   "init",
+				Usage:  "Initialize a .version file (auto-detects Git tag or starts from 0.1.0)",
+				Action: initVersion(),
+			},
+			{
 				Name:   "patch",
 				Usage:  "Increment patch version",
 				Action: bumpPatch(),

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -29,6 +30,8 @@ var (
 	execCommand = exec.Command
 
 	errInvalidVersion = errors.New("invalid version format")
+
+	InitializeVersionFile = initializeVersionFile
 )
 
 // String returns the string representation of the semantic version.
@@ -42,7 +45,7 @@ func (v SemVersion) String() string {
 // InitializeVersionFile initializes a .version file at the given path.
 // If the file already exists, it does nothing.
 // If not, it attempts to use the latest git tag (if valid), or falls back to 0.1.0.
-func InitializeVersionFile(path string) error {
+func initializeVersionFile(path string) error {
 	if _, err := os.Stat(path); err == nil {
 		return nil // Already exists
 	}
@@ -63,6 +66,27 @@ func InitializeVersionFile(path string) error {
 	return SaveVersion(path, version)
 }
 
+func InitializeVersionFileWithFeedback(path string) (created bool, version SemVersion, err error) {
+	if _, err := os.Stat(path); err == nil {
+		// File exists → return parsed version, not created
+		v, readErr := ReadVersion(path)
+		return false, v, readErr
+	}
+
+	// Call existing logic
+	err = InitializeVersionFile(path)
+	if err != nil {
+		return false, SemVersion{}, err
+	}
+
+	v, err := ReadVersion(path) // re-read to show the actual result
+	if err != nil {
+		return true, SemVersion{}, err // file was created but content invalid
+	}
+
+	return true, v, nil
+}
+
 // ReadVersion reads a version string from the given file and parses it into a SemVersion.
 func ReadVersion(path string) (SemVersion, error) {
 	data, err := os.ReadFile(path)
@@ -74,6 +98,10 @@ func ReadVersion(path string) (SemVersion, error) {
 
 // SaveVersion writes a SemVersion to the given file path.
 func SaveVersion(path string, version SemVersion) error {
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
 	return os.WriteFile(path, []byte(version.String()+"\n"), VersionFilePerm)
 }
 


### PR DESCRIPTION
- Added an `init` command to initialize the version file.
- Implemented a feedback mechanism during the initialization process.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #8 
- <kbd>&nbsp;1&nbsp;</kbd> #7 👈 
<!-- GitButler Footer Boundary Bottom -->

