### PR TITLE
feat/set-validate-no_init

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ USAGE:
    semver [global options] [command [command options]]
 
 VERSION:
-   v0.2.0
+   v0.3.0
 
 COMMANDS:
    init     Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
@@ -101,6 +101,7 @@ COMMANDS:
    major    Increment major version and reset minor and patch
    pre      Set pre-release label (e.g., alpha, beta.1)
    show     Display current version
+   set      Set the version manually
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
@@ -196,6 +197,20 @@ semver minor
 # .version = 1.2.3
 semver major
 # => 2.0.0
+```
+
+**Set a specific number**
+
+```bash
+semver set 2.1.0
+# => .version is now 2.1.0
+```
+
+You can also set a pre-release version:
+
+```bash
+semver set 2.1.0 --pre beta.1
+# => .version is now 2.1.0-beta.1
 ```
 
 **Set a pre-release label**

--- a/README.md
+++ b/README.md
@@ -95,14 +95,15 @@ VERSION:
    v0.3.0
 
 COMMANDS:
-   init     Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
-   patch    Increment patch version
-   minor    Increment minor version and reset patch
-   major    Increment major version and reset minor and patch
-   pre      Set pre-release label (e.g., alpha, beta.1)
-   show     Display current version
-   set      Set the version manually
-   help, h  Shows a list of commands or help for one command
+   init      Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
+   patch     Increment patch version
+   minor     Increment minor version and reset patch
+   major     Increment major version and reset minor and patch
+   pre       Set pre-release label (e.g., alpha, beta.1)
+   show      Display current version
+   set       Set the version manually
+   validate  Validate the .version file
+   help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --path value, -p value  Path to .version file (default: ".version")
@@ -241,6 +242,24 @@ semver pre --label alpha --inc
 # .version = 1.2.3
 semver pre --label alpha --inc
 # => 1.2.3-alpha.1
+```
+
+**Validate the version file**
+
+Check whether the `.version` file exists and contains a valid semantic version:
+
+```bash
+# .version = 1.2.3
+semver validate
+# => Valid version file at ./<path>/.version
+```
+
+If the file is missing or contains an invalid value, an error is returned:
+
+```bash
+# .version = invalid-content
+semver validate
+# => Error: invalid version format: ...
 ```
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 ## 📖 Table of Contents
 
 - [✨ Features](#-features)
+- [❓ Why .version?](#-why-version)
 - [💻 Installation](#-installation)
 - [🛠️ CLI Commands & Options](#️-cli-commands--options)
 - [⚙️ Configuration](#️-configuration)
@@ -42,21 +43,41 @@
 
 ## ✨ Features
 
-- Initialize version file using `init` command
-- Bump patch, minor, or major versions
-- Add or update pre-release labels (`alpha`, `beta.1`, etc.)
-- Auto-increment pre-release versions
-- Show current version
+- [SemVer 2.0.0](https://semver.org/) compliant
+- **Lightweight .version file** to store and track version across environments
+- `init` command to bootstrap the .version file from Git or default to `0.1.0`
+- Bump versions with patch, minor, or major
+- Add or update **pre-release labels** like `alpha`, `beta.1`, `rc.2`, etc.
+- Auto-increment pre-releases (`--inc`)
+- `set` command for full manual control (including pre-release)
+- `show` current version — perfect for CI/CD build outputs
+- `validate` the `.version` file for correctness
+- `--no-auto-init` mode for strict CI/CD environments
+- Configurable via flag, environment, or `.semver.yaml`
+
+## ❓ Why .version?
+
+Many Go projects — especially CLIs and internal tools — need a simple way to track their version outside of `go.mod`.
+
+Using a `.version` file:
+
+- ✅ Keeps the version readable and accessible at the project root
+- ✅ Works with any language, not just Go
+- ✅ Is easy to diff and track in Git
+- ✅ Plays well with CI/CD pipelines (e.g., Docker labels, GitHub Actions)
+- ✅ Lets you embed the version with something like `getVersion()` in your app
+
+This project was built with that workflow in mind — it's not for every use case, but if you're managing your app version manually, `.version` is a clean and flexible choice.
 
 ## 💻 Installation
 
-#### Option 1: Install via `go install` (global)
+### Option 1: Install via `go install` (global)
 
 ```bash
 go install github.com/indaco/semver-cli/cmd/semver@latest
 ```
 
-#### Option 2: Install via `go install` (tool)
+### Option 2: Install via `go install` (tool)
 
 With Go 1.24 or greater installed, you can install `semver` locally in your project by running:
 
@@ -70,11 +91,11 @@ Once installed, use it with
 go tool semver
 ```
 
-#### Option 3: Prebuilt binaries
+### Option 3: Prebuilt binaries
 
 Download the pre-compiled binaries from the [releases page](https://github.com/indaco/semver/releases) and place the binary in your system’s PATH.
 
-#### Option 4: Clone and build manually
+### Option 4: Clone and build manually
 
 ```bash
 git clone https://github.com/indaco/semver-cli.git

--- a/README.md
+++ b/README.md
@@ -95,20 +95,21 @@ VERSION:
    v0.3.0
 
 COMMANDS:
-   init      Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
+   show      Display current version
+   set       Set the version manually
    patch     Increment patch version
    minor     Increment minor version and reset patch
    major     Increment major version and reset minor and patch
    pre       Set pre-release label (e.g., alpha, beta.1)
-   show      Display current version
-   set       Set the version manually
    validate  Validate the .version file
+   init      Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
    help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --path value, -p value  Path to .version file (default: ".version")
-   --help, -h              show help
-   --version, -v           print the version
+   --path string, -p string  Path to .version file (default: ".version")
+   --no-auto-init            Disable auto-initialization of the .version file (default: false)
+   --help, -h                show help
+   --version, -v             print the version
 ```
 
 ## ⚙️ Configuration
@@ -159,21 +160,44 @@ You can also specify a custom path:
 semver init --path internal/version/.version
 ```
 
-## 🚀 Usage
+This behavior ensures your project always has a valid version starting point.
 
-**Initialize .version file**
+**To disable auto-initialization**, use the `--no-auto-init` flag.
+This is useful in CI/CD environments or stricter workflows where you want the command to fail if the file is missing:
 
 ```bash
-semver init
-# => Initialized .version with version 0.1.0
+semver patch --no-auto-init
+# => Error: .version file not found
 ```
 
-**Show the current version**
+## 🚀 Usage
+
+**Display current version**
 
 ```bash
 # .version = 1.2.3
 semver show
 # => 1.2.3
+```
+
+```bash
+# Fail if .version is missing (no auto-initialization)
+semver show --no-auto-init
+# => Error: failed to read version file at .version: no such file or directory
+```
+
+**Set version manually**
+
+```bash
+semver set 2.1.0
+# => .version is now 2.1.0
+```
+
+You can also set a pre-release version:
+
+```bash
+semver set 2.1.0 --pre beta.1
+# => .version is now 2.1.0-beta.1
 ```
 
 **Bump patch version**
@@ -200,21 +224,7 @@ semver major
 # => 2.0.0
 ```
 
-**Set a specific number**
-
-```bash
-semver set 2.1.0
-# => .version is now 2.1.0
-```
-
-You can also set a pre-release version:
-
-```bash
-semver set 2.1.0 --pre beta.1
-# => .version is now 2.1.0-beta.1
-```
-
-**Set a pre-release label**
+**Manage pre-release versions**
 
 ```bash
 # .version = 0.2.1
@@ -244,7 +254,7 @@ semver pre --label alpha --inc
 # => 1.2.3-alpha.1
 ```
 
-**Validate the version file**
+**Validate .version file**
 
 Check whether the `.version` file exists and contains a valid semantic version:
 
@@ -260,6 +270,13 @@ If the file is missing or contains an invalid value, an error is returned:
 # .version = invalid-content
 semver validate
 # => Error: invalid version format: ...
+```
+
+**Initialize .version file**
+
+```bash
+semver init
+# => Initialized .version with version 0.1.0
 ```
 
 ## 🤝 Contributing

--- a/cmd/semver/actions.go
+++ b/cmd/semver/actions.go
@@ -145,3 +145,15 @@ func setVersion() func(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 }
+
+func validateVersion() func(ctx context.Context, cmd *cli.Command) error {
+	return func(ctx context.Context, cmd *cli.Command) error {
+		path := cmd.String("path")
+		_, err := semver.ReadVersion(path)
+		if err != nil {
+			return fmt.Errorf("invalid version file at %s: %w", path, err)
+		}
+		fmt.Printf("Valid version file at %s\n", path)
+		return nil
+	}
+}

--- a/cmd/semver/actions.go
+++ b/cmd/semver/actions.go
@@ -118,3 +118,30 @@ func showVersion() func(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 }
+
+func setVersion() func(ctx context.Context, cmd *cli.Command) error {
+	return func(ctx context.Context, cmd *cli.Command) error {
+		path := cmd.String("path")
+		args := cmd.Args()
+
+		if args.Len() < 1 {
+			return cli.Exit("missing required version argument", 1)
+		}
+
+		raw := args.Get(0)
+		pre := cmd.String("pre")
+
+		version, err := semver.ParseVersion(raw)
+		if err != nil {
+			return fmt.Errorf("invalid version: %w", err)
+		}
+		version.PreRelease = pre
+
+		if err := semver.SaveVersion(path, version); err != nil {
+			return fmt.Errorf("failed to save version: %w", err)
+		}
+
+		fmt.Printf("Set version to %s in %s\n", version.String(), path)
+		return nil
+	}
+}

--- a/cmd/semver/actions.go
+++ b/cmd/semver/actions.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/indaco/semver-cli/internal/semver"
 	"github.com/urfave/cli/v3"
@@ -11,9 +12,15 @@ import (
 func initVersion() func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		path := cmd.String("path")
-		created, version, err := semver.InitializeVersionFileWithFeedback(path)
+
+		created, err := semver.InitializeVersionFileWithFeedback(path)
 		if err != nil {
 			return err
+		}
+
+		version, err := semver.ReadVersion(path)
+		if err != nil {
+			return fmt.Errorf("failed to read version file at %s: %w", path, err)
 		}
 
 		if created {
@@ -30,12 +37,8 @@ func bumpPatch() func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		path := cmd.String("path")
 
-		created, _, err := semver.InitializeVersionFileWithFeedback(path)
-		if err != nil {
+		if _, err := getOrInitVersionFile(cmd); err != nil {
 			return err
-		}
-		if created {
-			fmt.Printf("Auto-initialized %s with default version\n", path)
 		}
 
 		return semver.UpdateVersion(path, "patch")
@@ -47,12 +50,8 @@ func bumpMinor() func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		path := cmd.String("path")
 
-		created, _, err := semver.InitializeVersionFileWithFeedback(path)
-		if err != nil {
+		if _, err := getOrInitVersionFile(cmd); err != nil {
 			return err
-		}
-		if created {
-			fmt.Printf("Auto-initialized %s with default version\n", path)
 		}
 
 		return semver.UpdateVersion(path, "minor")
@@ -64,12 +63,8 @@ func bumpMajor() func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		path := cmd.String("path")
 
-		created, _, err := semver.InitializeVersionFileWithFeedback(path)
-		if err != nil {
+		if _, err := getOrInitVersionFile(cmd); err != nil {
 			return err
-		}
-		if created {
-			fmt.Printf("Auto-initialized %s with default version\n", path)
 		}
 
 		return semver.UpdateVersion(path, "major")
@@ -83,12 +78,13 @@ func setPreRelease() func(ctx context.Context, cmd *cli.Command) error {
 		label := cmd.String("label")
 		inc := cmd.Bool("inc")
 
-		created, version, err := semver.InitializeVersionFileWithFeedback(path)
-		if err != nil {
+		if _, err := getOrInitVersionFile(cmd); err != nil {
 			return err
 		}
-		if created {
-			fmt.Printf("Auto-initialized %s with default version\n", path)
+
+		version, err := semver.ReadVersion(path)
+		if err != nil {
+			return fmt.Errorf("failed to read version: %w", err)
 		}
 
 		if inc {
@@ -100,15 +96,22 @@ func setPreRelease() func(ctx context.Context, cmd *cli.Command) error {
 			version.PreRelease = label
 		}
 
-		return semver.SaveVersion(path, version)
+		if err := semver.SaveVersion(path, version); err != nil {
+			return fmt.Errorf("failed to save version: %w", err)
+		}
+
+		return nil
 	}
 }
 
-// showVersion prints the current version to stdout.
 func showVersion() func(ctx context.Context, cmd *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
-		path := cmd.String("path")
+		_, err := getOrInitVersionFile(cmd)
+		if err != nil {
+			return err
+		}
 
+		path := cmd.String("path")
 		version, err := semver.ReadVersion(path)
 		if err != nil {
 			return fmt.Errorf("failed to read version file at %s: %w", path, err)
@@ -156,4 +159,27 @@ func validateVersion() func(ctx context.Context, cmd *cli.Command) error {
 		fmt.Printf("Valid version file at %s\n", path)
 		return nil
 	}
+}
+
+// getOrInitVersionFile handles .version file initialization or returns an error
+// if auto-init is disabled and the file is missing.
+func getOrInitVersionFile(cmd *cli.Command) (created bool, err error) {
+	path := cmd.String("path")
+	noAutoInit := cmd.Bool("no-auto-init")
+
+	if noAutoInit {
+		if _, err := os.Stat(path); err != nil {
+			return false, cli.Exit(fmt.Sprintf("version file not found at %s", path), 1)
+		}
+		return false, nil
+	}
+
+	created, err = semver.InitializeVersionFileWithFeedback(path)
+	if err != nil {
+		return false, err
+	}
+	if created {
+		fmt.Printf("Auto-initialized %s with default version\n", path)
+	}
+	return created, nil
 }

--- a/cmd/semver/actions_test.go
+++ b/cmd/semver/actions_test.go
@@ -393,7 +393,9 @@ func TestCLI_PreCommand_SaveVersionFails(t *testing.T) {
 			fmt.Fprintln(os.Stderr, "failed to chmod .version file:", err)
 			os.Exit(1)
 		}
-		defer os.Chmod(versionPath, 0644) // cleanup
+		defer func() {
+			_ = os.Chmod(versionPath, 0644) // cleanup
+		}()
 
 		app := newCLI(versionPath)
 		err := app.Run(context.Background(), []string{

--- a/cmd/semver/actions_test.go
+++ b/cmd/semver/actions_test.go
@@ -246,18 +246,30 @@ func TestCLI_InitCommand_FileAlreadyExists(t *testing.T) {
 	}
 }
 
-func TestCLI_ShowCommand_FileNotFound(t *testing.T) {
+func TestCLI_InitCommand_ReadVersionFails(t *testing.T) {
 	tmp := t.TempDir()
-	defaultPath := filepath.Join(tmp, ".version")
-	app := newCLI(defaultPath)
+	path := filepath.Join(tmp, ".version")
 
-	err := app.Run(context.Background(), []string{"semver", "show", "--path", "./missing.version"})
-	if err == nil {
-		t.Fatal("expected error due to missing version file, got nil")
+	// Override InitializeVersionFile to write invalid content
+	original := semver.InitializeVersionFile
+	semver.InitializeVersionFile = func(p string) error {
+		return os.WriteFile(p, []byte("not-a-version\n"), 0600)
 	}
+	t.Cleanup(func() { semver.InitializeVersionFile = original })
 
-	if !strings.Contains(err.Error(), "no such file") {
+	app := newCLI(path)
+
+	err := app.Run(context.Background(), []string{
+		"semver", "init", "--path", path,
+	})
+	if err == nil {
+		t.Fatal("expected error due to invalid version content, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read version file") {
 		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid version format") {
+		t.Errorf("expected invalid version format message, got %v", err)
 	}
 }
 
@@ -365,6 +377,48 @@ func TestCLI_PreCommand_InitializeVersionFileError(t *testing.T) {
 	}
 }
 
+func TestCLI_PreCommand_SaveVersionFails(t *testing.T) {
+	if os.Getenv("TEST_SEMVER_PRE_SAVE_FAIL") == "1" {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+
+		// Write a valid version
+		if err := os.WriteFile(versionPath, []byte("1.2.3\n"), 0444); err != nil {
+			fmt.Fprintln(os.Stderr, "failed to write .version file:", err)
+			os.Exit(1)
+		}
+
+		// Ensure the file itself is read-only
+		if err := os.Chmod(versionPath, 0444); err != nil {
+			fmt.Fprintln(os.Stderr, "failed to chmod .version file:", err)
+			os.Exit(1)
+		}
+		defer os.Chmod(versionPath, 0644) // cleanup
+
+		app := newCLI(versionPath)
+		err := app.Run(context.Background(), []string{
+			"semver", "pre", "--label", "rc", "--path", versionPath,
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0) // Unexpected success
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCLI_PreCommand_SaveVersionFails")
+	cmd.Env = append(os.Environ(), "TEST_SEMVER_PRE_SAVE_FAIL=1")
+	output, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatal("expected error due to save failure, got nil")
+	}
+
+	if !strings.Contains(string(output), "failed to save version") {
+		t.Errorf("expected wrapped error message, got: %q", string(output))
+	}
+}
+
 func TestCLI_SetVersion_InvalidFormat(t *testing.T) {
 	tmp := t.TempDir()
 	app := newCLI(filepath.Join(tmp, ".version"))
@@ -455,6 +509,69 @@ func TestCLI_ValidateCommand_MissingFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no such file") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCLI_ShowCommand_NoAutoInit_MissingFile(t *testing.T) {
+	if os.Getenv("TEST_SEMVER_NO_AUTO_INIT") == "1" {
+		tmp := t.TempDir()
+		versionPath := filepath.Join(tmp, ".version")
+
+		app := newCLI(versionPath)
+		err := app.Run(context.Background(), []string{"semver", "show", "--no-auto-init"})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCLI_ShowCommand_NoAutoInit_MissingFile")
+	cmd.Env = append(os.Environ(), "TEST_SEMVER_NO_AUTO_INIT=1")
+	output, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatal("expected non-zero exit status")
+	}
+
+	expected := "version file not found"
+	if !strings.Contains(string(output), expected) {
+		t.Errorf("expected output to contain %q, got %q", expected, string(output))
+	}
+}
+func TestCLI_ShowCommand_NoAutoInit_FileExists(t *testing.T) {
+	tmp := t.TempDir()
+	writeVersionFile(t, tmp, "1.2.3")
+
+	output := captureStdout(func() {
+		runCLITest(t, []string{"semver", "show", "--no-auto-init"}, tmp)
+	})
+
+	if output != "1.2.3" {
+		t.Errorf("expected output '1.2.3', got %q", output)
+	}
+}
+
+func TestCLI_ShowCommand_InvalidVersionContent(t *testing.T) {
+	tmp := t.TempDir()
+	versionPath := filepath.Join(tmp, ".version")
+
+	// Write an invalid version string
+	if err := os.WriteFile(versionPath, []byte("not-a-semver\n"), 0644); err != nil {
+		t.Fatalf("failed to write invalid version: %v", err)
+	}
+
+	app := newCLI(versionPath)
+
+	err := app.Run(context.Background(), []string{"semver", "show"})
+	if err == nil {
+		t.Fatal("expected error due to invalid version, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to read version file at") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid version format") {
+		t.Errorf("error does not mention 'invalid version format': %v", err)
 	}
 }
 

--- a/cmd/semver/cli.go
+++ b/cmd/semver/cli.go
@@ -82,6 +82,11 @@ func newCLI(defaultPath string) *cli.Command {
 				},
 				Action: setVersion(),
 			},
+			{
+				Name:   "validate",
+				Usage:  "Validate the .version file",
+				Action: validateVersion(),
+			},
 		},
 	}
 }

--- a/cmd/semver/cli.go
+++ b/cmd/semver/cli.go
@@ -24,28 +24,33 @@ func newCLI(defaultPath string) *cli.Command {
 		},
 		Commands: []*cli.Command{
 			{
-				Name:   "init",
-				Usage:  "Initialize a .version file (auto-detects Git tag or starts from 0.1.0)",
-				Action: initVersion(),
+				Name:      "init",
+				Usage:     "Initialize a .version file (auto-detects Git tag or starts from 0.1.0)",
+				UsageText: "semver init",
+				Action:    initVersion(),
 			},
 			{
-				Name:   "patch",
-				Usage:  "Increment patch version",
-				Action: bumpPatch(),
+				Name:      "patch",
+				Usage:     "Increment patch version",
+				UsageText: "semver patch",
+				Action:    bumpPatch(),
 			},
 			{
-				Name:   "minor",
-				Usage:  "Increment minor version and reset patch",
-				Action: bumpMinor(),
+				Name:      "minor",
+				Usage:     "Increment minor version and reset patch",
+				UsageText: "semver minor",
+				Action:    bumpMinor(),
 			},
 			{
-				Name:   "major",
-				Usage:  "Increment major version and reset minor and patch",
-				Action: bumpMajor(),
+				Name:      "major",
+				Usage:     "Increment major version and reset minor and patch",
+				UsageText: "semver major",
+				Action:    bumpMajor(),
 			},
 			{
-				Name:  "pre",
-				Usage: "Set pre-release label (e.g., alpha, beta.1)",
+				Name:      "pre",
+				Usage:     "Set pre-release label (e.g., alpha, beta.1)",
+				UsageText: "semver pre --label <label> [--inc]",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "label",
@@ -60,9 +65,22 @@ func newCLI(defaultPath string) *cli.Command {
 				Action: setPreRelease(),
 			},
 			{
-				Name:   "show",
-				Usage:  "Display current version",
-				Action: showVersion(),
+				Name:      "show",
+				Usage:     "Display current version",
+				UsageText: "semver show",
+				Action:    showVersion(),
+			},
+			{
+				Name:      "set",
+				Usage:     "Set the version manually",
+				UsageText: "semver set <version> [--pre label]",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "pre",
+						Usage: "Optional pre-release label",
+					},
+				},
+				Action: setVersion(),
 			},
 		},
 	}

--- a/cmd/semver/cli.go
+++ b/cmd/semver/cli.go
@@ -21,13 +21,29 @@ func newCLI(defaultPath string) *cli.Command {
 				Usage:   "Path to .version file",
 				Value:   defaultPath,
 			},
+			&cli.BoolFlag{
+				Name:  "no-auto-init",
+				Usage: "Disable auto-initialization of the .version file",
+			},
 		},
 		Commands: []*cli.Command{
 			{
-				Name:      "init",
-				Usage:     "Initialize a .version file (auto-detects Git tag or starts from 0.1.0)",
-				UsageText: "semver init",
-				Action:    initVersion(),
+				Name:      "show",
+				Usage:     "Display current version",
+				UsageText: "semver show",
+				Action:    showVersion(),
+			},
+			{
+				Name:      "set",
+				Usage:     "Set the version manually",
+				UsageText: "semver set <version> [--pre label]",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "pre",
+						Usage: "Optional pre-release label",
+					},
+				},
+				Action: setVersion(),
 			},
 			{
 				Name:      "patch",
@@ -65,27 +81,15 @@ func newCLI(defaultPath string) *cli.Command {
 				Action: setPreRelease(),
 			},
 			{
-				Name:      "show",
-				Usage:     "Display current version",
-				UsageText: "semver show",
-				Action:    showVersion(),
-			},
-			{
-				Name:      "set",
-				Usage:     "Set the version manually",
-				UsageText: "semver set <version> [--pre label]",
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:  "pre",
-						Usage: "Optional pre-release label",
-					},
-				},
-				Action: setVersion(),
-			},
-			{
 				Name:   "validate",
 				Usage:  "Validate the .version file",
 				Action: validateVersion(),
+			},
+			{
+				Name:      "init",
+				Usage:     "Initialize a .version file (auto-detects Git tag or starts from 0.1.0)",
+				UsageText: "semver init",
+				Action:    initVersion(),
 			},
 		},
 	}

--- a/cmd/semver/main.go
+++ b/cmd/semver/main.go
@@ -22,7 +22,7 @@ func runCLI(args []string) error {
 
 	defaultPath := ".version"
 	if cfg != nil && cfg.Path != "" {
-		defaultPath = cfg.Path
+		defaultPath = config.NormalizeVersionPath(cfg.Path)
 	}
 
 	app := newCLI(defaultPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -37,4 +38,15 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// NormalizeVersionPath ensures the path is a file, not just a directory.
+func NormalizeVersionPath(path string) string {
+	info, err := os.Stat(path)
+	if err == nil && info.IsDir() {
+		return filepath.Join(path, ".version")
+	}
+
+	// If it doesn't exist or is already a file, return as-is
+	return path
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,22 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 	}
 }
 
+func TestNormalizeVersionPath(t *testing.T) {
+	// Case 1: path is a file
+	got := NormalizeVersionPath("foo/.version")
+	if got != "foo/.version" {
+		t.Errorf("expected unchanged path, got %q", got)
+	}
+
+	// Case 2: path is a directory
+	tmp := t.TempDir()
+	got = NormalizeVersionPath(tmp)
+	expected := filepath.Join(tmp, ".version")
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
 /* ------------------------------------------------------------------------- */
 /* ERROR CASES                                                               */
 /* ------------------------------------------------------------------------- */

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -66,25 +66,18 @@ func initializeVersionFile(path string) error {
 	return SaveVersion(path, version)
 }
 
-func InitializeVersionFileWithFeedback(path string) (created bool, version SemVersion, err error) {
+func InitializeVersionFileWithFeedback(path string) (created bool, err error) {
 	if _, err := os.Stat(path); err == nil {
-		// File exists → return parsed version, not created
-		v, readErr := ReadVersion(path)
-		return false, v, readErr
+		// File exists → not created; do NOT read or parse
+		return false, nil
 	}
 
-	// Call existing logic
 	err = InitializeVersionFile(path)
 	if err != nil {
-		return false, SemVersion{}, err
+		return false, err
 	}
 
-	v, err := ReadVersion(path) // re-read to show the actual result
-	if err != nil {
-		return true, SemVersion{}, err // file was created but content invalid
-	}
-
-	return true, v, nil
+	return true, nil
 }
 
 // ReadVersion reads a version string from the given file and parses it into a SemVersion.

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -58,7 +58,7 @@ func initializeVersionFile(path string) error {
 		tag := strings.TrimSpace(string(output))
 		tag = strings.TrimPrefix(tag, "v")
 
-		if parsed, parseErr := parseVersion(tag); parseErr == nil {
+		if parsed, parseErr := ParseVersion(tag); parseErr == nil {
 			version = parsed
 		}
 	}
@@ -93,7 +93,7 @@ func ReadVersion(path string) (SemVersion, error) {
 	if err != nil {
 		return SemVersion{}, err
 	}
-	return parseVersion(string(data))
+	return ParseVersion(string(data))
 }
 
 // SaveVersion writes a SemVersion to the given file path.
@@ -157,9 +157,9 @@ func IncrementPreRelease(current, base string) string {
 	return formatPreRelease(base, 1)
 }
 
-// parseVersion parses a semantic version string and returns a SemVersion.
+// ParseVersion parses a semantic version string and returns a SemVersion.
 // Returns an error if the version format is invalid.
-func parseVersion(s string) (SemVersion, error) {
+func ParseVersion(s string) (SemVersion, error) {
 	matches := versionRegex.FindStringSubmatch(strings.TrimSpace(s))
 	if len(matches) < 4 {
 		return SemVersion{}, errInvalidVersion

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -101,9 +101,9 @@ func TestParseAndString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		v, err := parseVersion(tt.raw)
+		v, err := ParseVersion(tt.raw)
 		if err != nil {
-			t.Errorf("parseVersion(%q) failed: %v", tt.raw, err)
+			t.Errorf("ParseVersion(%q) failed: %v", tt.raw, err)
 			continue
 		}
 		if v.String() != tt.expected {
@@ -114,28 +114,28 @@ func TestParseAndString(t *testing.T) {
 
 func TestParseVersion_ErrorCases(t *testing.T) {
 	t.Run("invalid format (missing patch)", func(t *testing.T) {
-		_, err := parseVersion("1.2")
+		_, err := ParseVersion("1.2")
 		if err == nil || !errors.Is(err, errInvalidVersion) {
 			t.Errorf("expected ErrInvalidVersion, got %v", err)
 		}
 	})
 
 	t.Run("non-numeric major", func(t *testing.T) {
-		_, err := parseVersion("a.2.3")
+		_, err := ParseVersion("a.2.3")
 		if err == nil || !errors.Is(err, errInvalidVersion) {
 			t.Errorf("expected ErrInvalidVersion, got %v", err)
 		}
 	})
 
 	t.Run("non-numeric minor", func(t *testing.T) {
-		_, err := parseVersion("1.b.3")
+		_, err := ParseVersion("1.b.3")
 		if err == nil || !errors.Is(err, errInvalidVersion) {
 			t.Errorf("expected ErrInvalidVersion, got %v", err)
 		}
 	})
 
 	t.Run("non-numeric patch", func(t *testing.T) {
-		_, err := parseVersion("1.2.c")
+		_, err := ParseVersion("1.2.c")
 		if err == nil || !errors.Is(err, errInvalidVersion) {
 			t.Errorf("expected ErrInvalidVersion, got %v", err)
 		}
@@ -153,7 +153,7 @@ func TestParseVersion_InvalidFormat(t *testing.T) {
 	}
 
 	for _, raw := range invalidVersions {
-		_, err := parseVersion(raw)
+		_, err := ParseVersion(raw)
 		if err == nil {
 			t.Errorf("expected error for invalid version %q, got nil", raw)
 		}
@@ -172,7 +172,7 @@ func TestParseVersion_NumberConversionErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			_, err := parseVersion(tt.input)
+			_, err := ParseVersion(tt.input)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}


### PR DESCRIPTION
- Added `set` command to manually set the version number.
- Introduced `validate` command to validate the .version file.
- Fixed file path normalization for correct file usage.
- Added `no-auto-init` flag and reorganized CLI commands.
- Updated README for enhanced clarity and structure.