### PR TITLE
refactor: unified `bump` command for `patch`, `minor` and `major`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ VERSION:
 COMMANDS:
    show      Display current version
    set       Set the version manually
-   patch     Increment patch version
-   minor     Increment minor version and reset patch
-   major     Increment major version and reset minor and patch
+   bump      Bump semantic version (patch, minor, major)
    pre       Set pre-release label (e.g., alpha, beta.1)
    validate  Validate the .version file
    init      Initialize a .version file (auto-detects Git tag or starts from 0.1.0)
@@ -221,27 +219,19 @@ semver set 2.1.0 --pre beta.1
 # => .version is now 2.1.0-beta.1
 ```
 
-**Bump patch version**
+**Bump version**
 
 ```bash
-# .version = 1.2.3
-semver patch
+semver show
+# => 1.2.3
+
+semver bump patch
 # => 1.2.4
-```
 
-**Bump minor version (and reset patch to 0)**
-
-```bash
-# .version = 1.2.3
-semver minor
+semver bump minor
 # => 1.3.0
-```
 
-**Bump major version (and reset minor/patch to 0)**
-
-```bash
-# .version = 1.2.3
-semver major
+semver bump major
 # => 2.0.0
 ```
 

--- a/cmd/semver/actions_test.go
+++ b/cmd/semver/actions_test.go
@@ -45,7 +45,7 @@ func TestCLI_BumpPatchCommand(t *testing.T) {
 	tmp := t.TempDir()
 	writeVersionFile(t, tmp, "1.2.3")
 
-	runCLITest(t, []string{"semver", "patch"}, tmp)
+	runCLITest(t, []string{"semver", "bump", "patch"}, tmp)
 
 	content, _ := os.ReadFile(filepath.Join(tmp, ".version"))
 	if got := strings.TrimSpace(string(content)); got != "1.2.4" {
@@ -57,7 +57,7 @@ func TestCLI_BumpPatchCommand_AutoInitFeedback(t *testing.T) {
 	tmp := t.TempDir()
 
 	output := captureStdout(func() {
-		runCLITest(t, []string{"semver", "patch"}, tmp)
+		runCLITest(t, []string{"semver", "bump", "patch"}, tmp)
 	})
 
 	expected := fmt.Sprintf("Auto-initialized %s with default version", filepath.Join(tmp, ".version"))
@@ -70,7 +70,7 @@ func TestCLI_BumpMinorCommand(t *testing.T) {
 	tmp := t.TempDir()
 	writeVersionFile(t, tmp, "1.2.3-alpha")
 
-	runCLITest(t, []string{"semver", "minor"}, tmp)
+	runCLITest(t, []string{"semver", "bump", "minor"}, tmp)
 
 	content, _ := os.ReadFile(filepath.Join(tmp, ".version"))
 	if got := strings.TrimSpace(string(content)); got != "1.3.0" {
@@ -82,7 +82,7 @@ func TestCLI_BumpMinorCommand_AutoInitFeedback(t *testing.T) {
 	tmp := t.TempDir()
 
 	output := captureStdout(func() {
-		runCLITest(t, []string{"semver", "minor"}, tmp)
+		runCLITest(t, []string{"semver", "bump", "minor"}, tmp)
 	})
 
 	expected := fmt.Sprintf("Auto-initialized %s with default version", filepath.Join(tmp, ".version"))
@@ -95,7 +95,7 @@ func TestCLI_BumpMajorCommand(t *testing.T) {
 	tmp := t.TempDir()
 	writeVersionFile(t, tmp, "1.2.3")
 
-	runCLITest(t, []string{"semver", "major"}, tmp)
+	runCLITest(t, []string{"semver", "bump", "major"}, tmp)
 
 	content, _ := os.ReadFile(filepath.Join(tmp, ".version"))
 	if got := strings.TrimSpace(string(content)); got != "2.0.0" {
@@ -107,7 +107,7 @@ func TestCLI_BumpMajorCommand_AutoInitFeedback(t *testing.T) {
 	tmp := t.TempDir()
 
 	output := captureStdout(func() {
-		runCLITest(t, []string{"semver", "major"}, tmp)
+		runCLITest(t, []string{"semver", "bump", "major"}, tmp)
 	})
 
 	expected := fmt.Sprintf("Auto-initialized %s with default version", filepath.Join(tmp, ".version"))
@@ -313,7 +313,7 @@ func TestCLI_BumpMinor_InitializeVersionFileError(t *testing.T) {
 	app := newCLI(defaultPath)
 
 	err := app.Run(context.Background(), []string{
-		"semver", "minor", "--path", protectedPath,
+		"semver", "bump", "minor", "--path", protectedPath,
 	})
 	if err == nil {
 		t.Fatal("expected error from InitializeVersionFile, got nil")
@@ -340,7 +340,7 @@ func TestCLI_BumpMajor_InitializeVersionFileError(t *testing.T) {
 	app := newCLI(defaultPath)
 
 	err := app.Run(context.Background(), []string{
-		"semver", "major", "--path", protectedPath,
+		"semver", "bump", "major", "--path", protectedPath,
 	})
 	if err == nil {
 		t.Fatal("expected error from InitializeVersionFile, got nil")

--- a/cmd/semver/cli.go
+++ b/cmd/semver/cli.go
@@ -46,22 +46,29 @@ func newCLI(defaultPath string) *cli.Command {
 				Action: setVersion(),
 			},
 			{
-				Name:      "patch",
-				Usage:     "Increment patch version",
-				UsageText: "semver patch",
-				Action:    bumpPatch(),
-			},
-			{
-				Name:      "minor",
-				Usage:     "Increment minor version and reset patch",
-				UsageText: "semver minor",
-				Action:    bumpMinor(),
-			},
-			{
-				Name:      "major",
-				Usage:     "Increment major version and reset minor and patch",
-				UsageText: "semver major",
-				Action:    bumpMajor(),
+				Name:      "bump",
+				Usage:     "Bump semantic version (patch, minor, major)",
+				UsageText: "semver bump <subcommand> [--flags]",
+				Commands: []*cli.Command{
+					{
+						Name:      "patch",
+						Usage:     "Increment patch version",
+						UsageText: "semver bump patch",
+						Action:    bumpPatch(),
+					},
+					{
+						Name:      "minor",
+						Usage:     "Increment minor version and reset patch",
+						UsageText: "semver bump minor",
+						Action:    bumpMinor(),
+					},
+					{
+						Name:      "major",
+						Usage:     "Increment major version and reset minor and patch",
+						UsageText: "semver bump major",
+						Action:    bumpMajor(),
+					},
+				},
 			},
 			{
 				Name:      "pre",

--- a/cmd/semver/cli_test.go
+++ b/cmd/semver/cli_test.go
@@ -23,7 +23,7 @@ func TestNewCLI_BasicStructure(t *testing.T) {
 
 	app := newCLI(versionPath)
 
-	wantCommands := []string{"patch", "minor", "major", "pre", "show"}
+	wantCommands := []string{"show", "set", "bump", "pre", "validate", "init"}
 	for _, name := range wantCommands {
 		found := false
 		for _, cmd := range app.Commands {
@@ -97,7 +97,7 @@ func TestNewCLI_UsesConfigPath(t *testing.T) {
 
 	app := newCLI(versionPath) // we still need to pass a dummy path
 
-	err = app.Run(context.Background(), []string{"semver", "patch"})
+	err = app.Run(context.Background(), []string{"semver", "bump", "patch"})
 	if err != nil {
 		t.Fatalf("app.Run failed: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestRunCLI_InitializeVersionFileError(t *testing.T) {
 		_ = os.Chdir(origDir)
 	})
 
-	err = runCLI([]string{"semver", "patch"})
+	err = runCLI([]string{"semver", "bump", "patch"})
 	if err == nil {
 		t.Fatal("expected error from InitializeVersionFile, got nil")
 	}

--- a/cmd/semver/main_test.go
+++ b/cmd/semver/main_test.go
@@ -82,7 +82,7 @@ func TestRunMain_SetupCLIError(t *testing.T) {
 		}
 	})
 
-	err = runCLI([]string{"semver", "patch"})
+	err = runCLI([]string{"semver", "bump", "patch"})
 	if err == nil {
 		t.Fatal("expected error from setupCLI, got nil")
 	}
@@ -116,7 +116,7 @@ func TestRunMain_LoadConfigError(t *testing.T) {
 		}
 	})
 
-	err = runCLI([]string{"semver", "patch"})
+	err = runCLI([]string{"semver", "bump", "patch"})
 	if err == nil {
 		t.Fatal("expected error from LoadConfig, got nil")
 	}


### PR DESCRIPTION
Restructured version bump commands to be organized under a new **unified** `bump` command with `patch`, `minor` and `major` as subcommands.